### PR TITLE
make code python2/python3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info
+test/*/*pdf
+test/*/*png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+# modernizer: make sure our code-base is Python 3 ready
+- repo: https://github.com/python-modernize/python-modernize.git
+  sha: a234ce4e185cf77a55632888f1811d83b4ad9ef2
+  hooks:
+  - id: python-modernize

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+
+language: python
+
+python:
+    - "2.7"
+    - "3.6"
+
+cache: pip
+
+
+install:
+    # Upgrade pip setuptools and wheel to be able to run the next command
+    - pip install -U pip==18.1 wheel setuptools
+    - pip install -e .[pre-commit]
+
+script:
+    - python -c "import pyiast;"

--- a/pyiast/iast.py
+++ b/pyiast/iast.py
@@ -2,13 +2,10 @@
 This module performs the heart of the IAST calculations, given the
 pure-component adsorption isotherm models from the `isotherms` module.
 """
+from __future__ import absolute_import
+from __future__ import print_function
+from six.moves import range
 __author__ = 'Cory M. Simon'
-
-# This code is written for Python 3.
-import sys
-if sys.version_info[0] != 3:
-    print("pyIAST now requires Python 3.")
-    sys.exit(1)
 
 from pyiast.isotherms import _MODELS, _MODEL_PARAMS, _VERSION, ModelIsotherm, \
     InterpolatorIsotherm, plot_isotherm

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
-import sys
+from __future__ import absolute_import
 from setuptools import setup
-
-if sys.version_info[0] != 3:
-    print("pyIAST now requires Python 3.")
-    sys.exit(1)
 
 setup(name='pyiast',
     version='1.4.2',
@@ -11,6 +7,10 @@ setup(name='pyiast',
     url='https://github.com/CorySimon/pyIAST',
     download_url='https://github.com/CorySimon/pyIAST/tarball/master',
     install_requires=['numpy', 'scipy', 'pandas', 'matplotlib'],
+    extras_require={'pre-commit': [
+        "pre-commit==1.14.4",
+        "yapf==0.26.0",
+    ]},
     keywords='chemistry isotherm iast',
     author='Cory M. Simon',
     author_email='CoryMSimon@gmail.com',


### PR DESCRIPTION
As requested, here comes the PR without the formatter

 * make code python2/python3 compatible
 * add .gitignore
 * add travis test
 * add pre-commit extra
 * remove python3 checks